### PR TITLE
Add logger features action support for status log forwarding

### DIFF
--- a/examples/logger-file/src/main.rs
+++ b/examples/logger-file/src/main.rs
@@ -3,7 +3,7 @@ mod cli;
 use chrono::Local;
 use clap::Parser;
 use log::info;
-use osquery_rust_ng::plugin::{LogSeverity, LogStatus, LoggerPlugin, Plugin};
+use osquery_rust_ng::plugin::{LogSeverity, LogStatus, LoggerFeatures, LoggerPlugin, Plugin};
 use osquery_rust_ng::prelude::*;
 use std::fs::{File, OpenOptions};
 use std::io::Write;
@@ -145,6 +145,10 @@ impl LoggerPlugin for FileLoggerPlugin {
             let _ = file.write_all(formatted.as_bytes());
             let _ = file.flush();
         }
+    }
+
+    fn features(&self) -> i32 {
+        LoggerFeatures::LOG_STATUS
     }
 }
 

--- a/osquery-rust/src/plugin/_enums/response.rs
+++ b/osquery-rust/src/plugin/_enums/response.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeMap;
 pub enum ExtensionResponseEnum {
     Success(),
     SuccessWithId(u64),
+    SuccessWithCode(i32),
     Failure(String),
     Constraint(),
     Readonly(),
@@ -23,6 +24,10 @@ impl From<ExtensionResponseEnum> for ExtensionResponse {
                 resp.insert("status".to_string(), "success".to_string());
                 resp.insert("id".to_string(), id.to_string());
                 0
+            }
+            ExtensionResponseEnum::SuccessWithCode(code) => {
+                resp.insert("status".to_string(), "success".to_string());
+                code
             }
             ExtensionResponseEnum::Failure(msg) => {
                 resp.insert("status".to_string(), "failure".to_string());

--- a/osquery-rust/src/plugin/mod.rs
+++ b/osquery-rust/src/plugin/mod.rs
@@ -19,4 +19,4 @@ pub use table::{DeleteResult, InsertResult, ReadOnlyTable, Table, UpdateResult};
 pub use _enums::response::ExtensionResponseEnum;
 
 pub use config::{ConfigPlugin, ConfigPluginWrapper};
-pub use logger::{LogSeverity, LogStatus, LoggerPlugin, LoggerPluginWrapper};
+pub use logger::{LogSeverity, LogStatus, LoggerFeatures, LoggerPlugin, LoggerPluginWrapper};


### PR DESCRIPTION
Logger plugins can now receive osquery status logs (INFO/WARNING/ERROR) by responding to the features action. Previously, the features request was not handled, causing osquery to assume no additional log types were supported.

Fix #1 